### PR TITLE
Empower pa-jail with its own gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@
 conf/gitssh_config
 conf/id_rsa_*
 conf/options.php
-jail/pa-jail
-jail/pa-timeout
-jail/pa-writefifo
-jail/stderrtostdout
 log/
 repo/
 .vagrant/

--- a/jail/.gitignore
+++ b/jail/.gitignore
@@ -1,0 +1,4 @@
+pa-jail
+pa-timeout
+pa-writefifo
+stderrtostdout


### PR DESCRIPTION
pa-jail is super-duper useful as a standalone product; if it doesn't
rely on the root .gitignore, it is entirely self-contained.

@kohler thoughts? This makes it possible to manage pa-jail as a Git subtree for the CS124 server. :grin: