### PR TITLE
Forward LANG env var along.

### DIFF
--- a/jail/pa-jail.cc
+++ b/jail/pa-jail.cc
@@ -1373,7 +1373,7 @@ class jailownerinfo {
     int exec_go();
 
   private:
-    const char* newenv[4];
+    const char* newenv[5];
     char** argv;
     jaildirinfo* jaildir;
     int inputfd;
@@ -1480,17 +1480,21 @@ void jailownerinfo::exec(int argc, char** argv, jaildirinfo& jaildir,
     char homebuf[8192];
     sprintf(homebuf, "HOME=%s", owner_home.c_str());
     const char* path = "PATH=/usr/local/bin:/bin:/usr/bin";
+    const char* lang = "LANG=C";
     const char* ld_library_path = NULL;
     {
         extern char** environ;
         for (char** eptr = environ; *eptr; ++eptr)
             if (strncmp(*eptr, "PATH=", 5) == 0)
                 path = *eptr;
+            else if (strncmp(*eptr, "LANG=", 5) == 0)
+                lang = *eptr;
             else if (strncmp(*eptr, "LD_LIBRARY_PATH=", 16) == 0)
                 ld_library_path = *eptr;
     }
     int newenvpos = 0;
     newenv[newenvpos++] = path;
+    newenv[newenvpos++] = lang;
     if (ld_library_path)
         newenv[newenvpos++] = ld_library_path;
     newenv[newenvpos++] = homebuf;


### PR DESCRIPTION
Python throws a fit if LANG is improperly set.