### PR TITLE
Handle tag-based psets

### DIFF
--- a/doc/psetsjson.md
+++ b/doc/psetsjson.md
@@ -169,6 +169,12 @@ others are shown to users in different contexts.
     the specified `directory`, if any). Used to detect when a student ignores
     the subdirectory structure.
 
+* `start_tag`: string
+
+    The name of a tag that should be used as the base for diffs instead of the
+    handout repository. Useful for assignments that build on previous
+    submissions.
+
 * `repo_guess_patterns`: array of strings
 
     These patterns are used to try to guess a student’s repository URL from

--- a/pset.php
+++ b/pset.php
@@ -649,6 +649,8 @@ function echo_commit($Info) {
         $x = utf8_substr($k->subject, 0, 72);
         if (strlen($x) != strlen($k->subject))
             $x .= "...";
+        if ($k->tags)
+            $x .= " (tags: " . htmlspecialchars(implode(", ", $k->tags)) . ")";
         $sel[$k->hash] = substr($k->hash, 0, 7) . " " . htmlspecialchars($x);
     }
     $result = $Conf->qe("select hash from CommitNotes where (haslinenotes&" . ($Me == $User && !$Info->can_see_grades ? HASNOTES_COMMENT : HASNOTES_ANY) . ")!=0 and pset=$Pset->psetid and hash in ('" . join("','", array_keys($sel)) . "')");

--- a/pset.php
+++ b/pset.php
@@ -690,6 +690,8 @@ function echo_commit($Info) {
 
     // warnings
     $remarks = array();
+    if (!$Info->has_start_tag())
+        $remarks[] = array(true, "You have not tagged your start commit with " . $Info->pset->start_tag . ".");
     if (!$Info->grading_hash() && $Me != $User && !$Pset->gitless_grades)
         $remarks[] = array(true, "No commit has been marked for grading.");
     else if (!$Info->is_grading_commit() && $Info->grading_hash())
@@ -822,6 +824,8 @@ function show_pset($info) {
     ContactView::echo_partner_group($info);
     ContactView::echo_repo_group($info, $Me != $info->user);
     ContactView::echo_repo_last_commit_group($info, false);
+    if ($info->pset->start_tag)
+        ContactView::echo_group("start tag", $info->pset->start_tag);
 }
 
 show_pset($Info);

--- a/pset.php
+++ b/pset.php
@@ -692,6 +692,10 @@ function echo_commit($Info) {
     $remarks = array();
     if (!$Info->has_start_tag())
         $remarks[] = array(true, "You have not tagged your start commit with " . $Info->pset->start_tag . ".");
+    else if ($Info->pset->start_tag && !$Info->start_tag_is_ancestor()) {
+        $type = $Info->grading_hash() ? "the grading" : "the latest";
+        $remarks[] = array(true, "Your start tag is not an ancestor of $type commit. Please re-tag the correct start commit with " . $Info->pset->start_tag . ".");
+    }
     if (!$Info->grading_hash() && $Me != $User && !$Pset->gitless_grades)
         $remarks[] = array(true, "No commit has been marked for grading.");
     else if (!$Info->is_grading_commit() && $Info->grading_hash())

--- a/src/contact.php
+++ b/src/contact.php
@@ -1485,6 +1485,10 @@ class Contact {
         return $list;
     }
 
+    static function repo_has_tag($repo, $tag) {
+        return self::repo_gitrun($repo, "git show-ref --verify -- refs/tags/REPO/$tag") !== null;
+    }
+
     static private function _file_glob_to_regex($x, $prefix) {
         $x = str_replace(array('\*', '\?', '\[', '\]', '\-', '_'),
                          array('[^/]*', '[^/]', '[', ']', '-', '\_'),
@@ -1623,7 +1627,9 @@ class Contact {
 
         if (@$options["basehash"])
             $base = $options["basehash"];
-        else {
+        elseif ($pset->start_tag) {
+            $base = "REPO/$pset->start_tag";
+        } else {
             $hrepo = self::handout_repo($pset, $repo);
             $base = "repo{$hrepo->repoid}/master";
             if ($pset && isset($pset->gradebranch))

--- a/src/gitfetch
+++ b/src/gitfetch
@@ -90,7 +90,7 @@ if test -f .git/FETCH_HEAD -a ! -w .git/FETCH_HEAD; then
     rm -f .git/FETCH_HEAD
 fi
 
-git fetch repo$repoid
+git fetch repo$repoid +refs/heads/*:refs/remotes/repo$repoid/* +refs/tags/*:refs/tags/repo$repoid/*
 gitfetch_status=$?
 
 now=`date '+%Y%m%d.%H%M%S<%s>%d/%b/%Y:%H:%M:%S %z'`

--- a/src/psetconfig.php
+++ b/src/psetconfig.php
@@ -41,6 +41,7 @@ class Pset {
     public $directory_slash;
     public $directory_noslash;
     public $test_file;
+    public $start_tag;
 
     public $deadline;
     public $deadline_college;
@@ -172,6 +173,7 @@ class Pset {
             $this->grade_cdf_visible = false;
         $this->grade_cdf_cutoff = self::cnum($p, "grade_cdf_cutoff");
         $this->separate_extension_grades = self::cbool($p, "separate_extension_grades");
+	$this->start_tag = @$p->start_tag;
 
         // runners
         if (is_array(@$p->runners) || is_object(@$p->runners)) {

--- a/src/psetview.php
+++ b/src/psetview.php
@@ -73,6 +73,10 @@ class PsetView {
             return false;
     }
 
+    public function has_start_tag() {
+        return !$this->pset->start_tag || $this->user->repo_has_tag($this->repo, $this->pset->start_tag);
+    }
+
     public function can_have_grades() {
         return $this->pset->gitless_grades || $this->commit();
     }

--- a/src/psetview.php
+++ b/src/psetview.php
@@ -77,6 +77,11 @@ class PsetView {
         return !$this->pset->start_tag || $this->user->repo_has_tag($this->repo, $this->pset->start_tag);
     }
 
+    public function start_tag_is_ancestor() {
+        $commit = $this->grading_commit() ?: $this->latest_commit();
+        return $commit && $this->user->repo_gitrun($this->repo, "git merge-base --is-ancestor REPO/" . $this->pset->start_tag . " " . $commit->hash . " && echo true");
+    }
+
     public function can_have_grades() {
         return $this->pset->gitless_grades || $this->commit();
     }


### PR DESCRIPTION
@kohler I suspect this isn't quite ready for merge—we might want to wait for this round of 161 A2 submissions to expose any bugs—but wanted your feedback.

This supports the 161 submission workflow by a) listing tags in the commit selector so students can label their intended grading commit with a tag, and b) allowing a start tag to be specified in the pset config so that pset diffs can be relative to the start tag instead of the handout repo, preventing monster diffs on later assignments.
