### PR TITLE
pa-jail: prevent truncated output

### DIFF
--- a/jail/pa-jail.cc
+++ b/jail/pa-jail.cc
@@ -1396,6 +1396,7 @@ class jailownerinfo {
         }
         void transfer_in(int from);
         void transfer_out(int to);
+        bool done();
     };
     buffer to_slave;
     buffer from_slave;
@@ -1787,6 +1788,10 @@ void jailownerinfo::buffer::transfer_out(int to) {
     }
 }
 
+bool jailownerinfo::buffer::done() {
+    return input_closed && head == tail;
+}
+
 void jailownerinfo::block(int ptymaster) {
     int maxfd = sigpipe[0];
     FD_SET(sigpipe[0], &readset);
@@ -1908,7 +1913,7 @@ void jailownerinfo::wait_background(pid_t child, int ptymaster) {
 
         // check child and timeout
         // (only wait for child if read done/failed)
-        int exit_status = check_child_timeout(child, from_slave.input_closed);
+        int exit_status = check_child_timeout(child, from_slave.done());
         if (exit_status != -1)
             exec_done(child, exit_status);
 


### PR DESCRIPTION
Commit message: stdout is non-blocking, so writes may fail when the kernel buffer fills
up. This means that a single call to `transfer_out` isn't guaranteed to
flush the local buffer, so we have to explicitly wait for the local
buffer to flush before we exit.

This fixes the secondary bug I mentioned in #16 where sometimes the output is just truncated (not just long lines).