### PR TITLE
pa-jail: fix sanitized relative paths

### DIFF
--- a/jail/pa-jail.cc
+++ b/jail/pa-jail.cc
@@ -1084,7 +1084,7 @@ static std::string absolute(const std::string& dir) {
     if (!dir.empty() && dir[0] == '/')
         return dir;
     char buf[BUFSIZ];
-    if (getcwd(buf, BUFSIZ - 1))
+    if (getcwd(buf, BUFSIZ - 1) == NULL)
         perror_die("getcwd");
     char* endbuf = buf + strlen(buf);
     while (endbuf - buf > 1 && endbuf[-1] == '/')


### PR DESCRIPTION
getcwd returns NULL on error; the current `absolute` function has it backwards.
This means that calling `absolute` with any path that isn't already absolute
crashes the program.

To reproduce, just call `pa-jail run` with a relative jail path:

```
$ pa-jail run --fg -f ~/jfiles jail jailuser true
```