### PR TITLE
pa-jail: properly set poll timeout

### DIFF
--- a/jail/pa-jail.cc
+++ b/jail/pa-jail.cc
@@ -1866,7 +1866,7 @@ void jailownerinfo::block(int ptymaster) {
     if (timerisset(&expiry)) {
         struct timeval now;
         gettimeofday(&now, 0);
-        if (timercmp(&now, &expiry, >)) {
+        if (timercmp(&now, &expiry, <)) {
             timersub(&expiry, &now, &now);
             timeout_ms = now.tv_sec * 1000 + now.tv_usec / 1000;
         } else


### PR DESCRIPTION
I'm like 99.99% sure this is backwards and it sometimes causes pa-jail to never kill a rogue process.