### PR TITLE
Stub out Contact::activate_database_account

### DIFF
--- a/src/contact.php
+++ b/src/contact.php
@@ -1353,4 +1353,8 @@ class Contact {
         else
             return $user->github_username ? : ($user->seascode_username ? : $user->huid);
     }
+
+    function activate_database_account() {
+        error_log("Contact::activate_database_account() is unimplemented!");
+    }
 }


### PR DESCRIPTION
`lib/login.php` calls `activate_database_account()` if `setupPhase` is active according to config.

I think the idea is that this creates the DB account if none exists; cf. #22.

The stub prevents users from receiving unexpected HTTP 500 responses at every login.