### PR TITLE
Optionally display anon user ID back to user

### DIFF
--- a/src/conference.php
+++ b/src/conference.php
@@ -1549,7 +1549,12 @@ class Conf {
             // profile link
             $profile_parts = [];
             if ($Me->has_email() && !$Me->disabled) {
-	        $profile_parts[] = '<strong>' . htmlspecialchars($Me->email) . '</strong>';
+                $u = '<strong>' . htmlspecialchars($Me->email) . '</strong> ';
+                if ($this->opt("showAnonUserID")) {
+                    $profile_parts[] = $u . ' ' . htmlspecialchars($Me->anon_username);
+                } else {
+                    $profile_parts[] = $u;
+                }
                 /*echo '<a class="q" href="', hoturl("profile"), '"><strong>',
                     htmlspecialchars($Me->email),
                     '</strong></a> &nbsp; <a href="', hoturl("profile"), '">Profile</a>',


### PR DESCRIPTION
This is helpful if the anon ID string is used for other purposes (e.g., when students complete an external survey).

Controlled by `$Opt["showAnonUserID"]`, `false` by default.