### PR TITLE
Actually allow dates for runner visibility

### DIFF
--- a/src/psetconfig.php
+++ b/src/psetconfig.php
@@ -1139,7 +1139,7 @@ class RunnerConfig {
         }
 
         $this->disabled = Pset::cbool($loc, $rs, "disabled");
-        $this->visible = Pset::cbool($loc, $rs, "visible", "show_to_students");
+        $this->visible = Pset::cdate_or_grades($loc, $rs, "visible", "show_to_students");
         $this->output_visible = Pset::cdate_or_grades($loc, $rs, "output_visible", "show_output_to_students", "show_results_to_students");
         $this->timeout = Pset::cinterval($loc, $rs, "timeout", "run_timeout");
         $this->xterm_js = Pset::cbool($loc, $rs, "xterm_js");


### PR DESCRIPTION
https://github.com/kohler/peteramati/blob/master/doc/psetsjson.md#run-entries says that `visible` is "boolean, date, or `grades`", but it was actually treated as a boolean in the psets.json validation logic. Other parts of the code already understand date values for it, and they work with this change.