### PR TITLE
Collator needs to be specified in siteloader

### DIFF
--- a/src/siteloader.php
+++ b/src/siteloader.php
@@ -13,7 +13,8 @@ class SiteLoader {
         "MimeText" => "lib/mailer.php",
         "Pset" => "src/psetconfig.php",
         "QueueStatus" => "src/queueitem.php",
-        "ZipDocument" => "lib/documenthelper.php"
+        "ZipDocument" => "lib/documenthelper.php",
+        "Collator" => "lib/collatorshim.php"
     ];
 
     static $suffix_map = [


### PR DESCRIPTION
The loader looks for collator.php because of the class name Collator; but the file is called collatorshim.php.

This fixes a fatal error due to a missing `require_once()` for collator.php:
```
[Fri Jan 21 20:58:07.914033 2022] [php7:error] [pid 175735] [client x.x.x.x:x] PHP Fatal error:  require_once(): Failed opening required '/opt/peteramati/www-dev/src/collator.php' (include_path='.:/usr/share/php') in /opt/peteramati/www-dev/src/siteloader.php on line 178
```