### PR TITLE
Remove lingering get() calls that broke mailer

### DIFF
--- a/lib/mailer.php
+++ b/lib/mailer.php
@@ -46,7 +46,7 @@ class Mailer {
         $this->recipient = $recipient;
         foreach (array("width", "sensitivity", "reason", "adminupdate", "notes",
                        "capability") as $k)
-            $this->$k = get($settings, $k);
+            $this->$k = $settings->$k ?? null;
         if ($this->width === null)
             $this->width = 75;
         else if (!$this->width)
@@ -448,10 +448,10 @@ class Mailer {
         $recipient = $this->recipient;
         if (!$recipient || !$recipient->email)
             return Conf::msg_error("no email in Mailer::send");
-        if (get($recipient, "preferredEmail")) {
+        if (isset($recipient->preferredEmail)) {
             $recipient = (object) array("email" => $recipient->preferredEmail);
             foreach (array("firstName", "lastName", "name", "fullName") as $k)
-                if (get($this->recipient, $k))
+                if (isset($this->recipient->$k))
                     $recipient->$k = $this->recipient->$k;
         }
         $prep->to = array(Text::user_email_to($recipient));


### PR DESCRIPTION
get() was deprecated in 214fdd26ae34f9db9eb994fc0497e868e73a328e and is no longer available in lib/mailer.php (at least on my setup; Debian 11, stock PHP 7.4), breaking email sending.

This removes two remaining calls to it in mailer.php.